### PR TITLE
Removed org.apache.commons.jxpath from ecf-2024-06.target

### DIFF
--- a/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
+++ b/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
@@ -30,7 +30,6 @@
       <unit id="org.apache.batik.css" version="0.0.0"/>
       <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
       <unit id="org.apache.commons.httpclient" version="0.0.0"/>
-      <unit id="org.apache.commons.jxpath" version="0.0.0"/>
       <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.client5.httpclient5" version="0.0.0"/>
       <unit id="org.apache.httpcomponents.client5.httpclient5-win" version="0.0.0"/>


### PR DESCRIPTION
Jipp problem using latest simrel repo location:

https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest/

Repo does not contain jxpath bundle and so trying to remove it from target to see if it is really needed.

