### PR TITLE
Restore org.eclipse.ecf.provider.filetransfer.httpclient5.win32

### DIFF
--- a/releng/features/org.eclipse.ecf.filetransfer.httpclient5.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.filetransfer.httpclient5.feature/feature.xml
@@ -30,4 +30,12 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.ecf.provider.filetransfer.httpclient5.win32"
+         os="win32"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
- The org.eclipse.ecf.provider.filetransfer.httpclient5.win32 bundle was accidentally removed from
org.eclipse.ecf.filetransfer.httpclient5.feature.