### PR TITLE
Remove runtime requirement on org.osgi.service.component.annotations

### DIFF
--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclient5/META-INF/MANIFEST.MF
@@ -56,7 +56,6 @@ Import-Package: org.apache.hc.client5.http;version="[5.1.3,6.0.0)",
  org.eclipse.osgi.service.debug;version="1.2.0",
  org.eclipse.osgi.util;version="1.1.0",
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.log;version="1.5.0",
  org.osgi.util.tracker;version="1.5.2"
 Bundle-ActivationPolicy: lazy

--- a/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
+++ b/providers/bundles/org.eclipse.ecf.provider.filetransfer.httpclientjava/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Import-Package: javax.net.ssl,
  org.eclipse.osgi.service.debug;version="1.2.0",
  org.eclipse.osgi.util;version="1.1.0",
  org.osgi.framework,
- org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.log;version="1.5.0",
  org.osgi.util.tracker;version="1.5.2"
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
These are needed only at build time for DS xml files generation and both Tycho and PDE will handle setting it up proper without needless explicit runtime dependency.