### PR TITLE
Added mcp transports support bundle

### DIFF
--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.classpath
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.project
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.ecf.ai.mcp.transports</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.core.resources.prefs
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=windows-1252

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.jdt.core.prefs
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.pde.core.prefs
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+pluginProject.extensions=false
+resolve.requirebundle=false

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundle.name
 Bundle-SymbolicName: org.eclipse.ecf.ai.mcp.transports
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Require-Bundle: slf4j.api
 Bundle-Vendor: %bundle.provider
 Automatic-Module-Name: org.eclipse.ecf.ai.mcp.transports

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %bundle.name
+Bundle-SymbolicName: org.eclipse.ecf.ai.mcp.transports
+Bundle-Version: 1.0.0.qualifier
+Require-Bundle: slf4j.api
+Bundle-Vendor: %bundle.provider
+Automatic-Module-Name: org.eclipse.ecf.ai.mcp.transports
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/about.html
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 25, 2008</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/build.properties
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/build.properties
@@ -1,0 +1,8 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.properties,\
+               about.html
+jre.compilation.profile = JavaSE-17
+

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/plugin.properties
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/plugin.properties
@@ -1,0 +1,11 @@
+############################################################################
+# Copyright (c) 2025 Composent Inc., and others.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+############################################################################
+bundle.name=ECF MCP Transports Support (UDS, Inet4, Inet6)
+bundle.provider=Eclipse.org - ECF

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/pom.xml
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.ecf</groupId>
+    <artifactId>ecf-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
+  
+  <artifactId>org.eclipse.ecf.ai.mcp.transports</artifactId>
+  <version>1.0.1-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/AbstractStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/AbstractStringChannel.java
@@ -1,0 +1,372 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractStringChannel {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractStringChannel.class);
+
+	public static final int DEFAULT_INBUFFER_SIZE = 1024;
+
+	public static String DEFAULT_MESSAGE_DELIMITER = "\n";
+
+	protected String messageDelimiter = DEFAULT_MESSAGE_DELIMITER;
+
+	protected void setMessageDelimiter(String delim) {
+		this.messageDelimiter = delim;
+	}
+
+	protected String getMessageDelimiter() {
+		return this.messageDelimiter;
+	}
+
+	public static int DEFAULT_WRITE_TIMEOUT = 5000; // ms
+
+	protected int writeTimeout = DEFAULT_WRITE_TIMEOUT;
+
+	protected void setWriteTimeout(int timeout) {
+		this.writeTimeout = timeout;
+	}
+
+	protected int getWriteTimeout() {
+		return this.writeTimeout;
+	}
+
+	public static int DEFAULT_CONNECT_TIMEOUT = 10000; // ms
+
+	protected int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+	protected void setConnectTimeout(int timeout) {
+		this.connectTimeout = timeout;
+	}
+
+	protected int getConnectTimeout() {
+		return this.connectTimeout;
+	}
+
+	public static int DEFAULT_TERMINATION_TIMEOUT = 2000; // ms
+
+	protected int terminationTimeout = DEFAULT_TERMINATION_TIMEOUT;
+
+	protected void setTerminationTimeout(int timeout) {
+		this.terminationTimeout = timeout;
+	}
+
+	protected int getTerminationTimeout() {
+		return this.terminationTimeout;
+	}
+
+	protected final Selector selector;
+
+	protected final ByteBuffer inBuffer;
+
+	protected final ExecutorService executor;
+
+	protected final Object writeLock = new Object();
+
+	@FunctionalInterface
+	public interface IOConsumer<T> {
+
+		void apply(T t) throws IOException;
+
+	}
+
+	protected class AttachedIO {
+
+		public ByteBuffer writing;
+
+		public StringBuffer reading;
+
+	}
+
+	public AbstractStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		Objects.requireNonNull(selector, "Selector must not be null");
+		this.selector = selector;
+		this.inBuffer = ByteBuffer.allocate(incomingBufferSize);
+		this.executor = (executor == null) ? Executors.newSingleThreadExecutor() : executor;
+	}
+
+	public AbstractStringChannel(Selector selector, int incomingBufferSize) {
+		this(selector, incomingBufferSize, null);
+	}
+
+	public AbstractStringChannel(Selector selector) {
+		this(selector, DEFAULT_INBUFFER_SIZE);
+	}
+
+	public AbstractStringChannel() throws IOException {
+		this(Selector.open());
+	}
+
+	protected Runnable getRunnableForProcessing(IOConsumer<SocketChannel> acceptHandler,
+			IOConsumer<SocketChannel> connectHandler, IOConsumer<String> readHandler) {
+		return () -> {
+			SelectionKey key = null;
+			try {
+				while (true) {
+					int count = this.selector.select();
+					debug("select returned count={}", count);
+					Set<SelectionKey> selectedKeys = selector.selectedKeys();
+					Iterator<SelectionKey> iter = selectedKeys.iterator();
+					while (iter.hasNext()) {
+						key = iter.next();
+						if (key.isConnectable()) {
+							handleConnectable(key, connectHandler);
+						} else if (key.isAcceptable()) {
+							handleAcceptable(key, acceptHandler);
+						} else if (key.isReadable()) {
+							handleReadable(key, readHandler);
+						} else if (key.isWritable()) {
+							handleWritable(key);
+						}
+						iter.remove();
+					}
+				}
+			} catch (Throwable e) {
+				handleException(key, e);
+			}
+		};
+	}
+
+	public abstract void close();
+
+	protected abstract void handleException(SelectionKey key, Throwable e);
+
+	protected void start(IOConsumer<SocketChannel> acceptHandler, IOConsumer<SocketChannel> connectHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		this.executor.execute(getRunnableForProcessing(acceptHandler, connectHandler, readHandler));
+	}
+
+	protected void debug(String format, Object... o) {
+		if (logger.isDebugEnabled()) {
+			logger.debug(format, o);
+		}
+	}
+
+	// For client subclasses
+	protected void handleConnectable(SelectionKey key, IOConsumer<SocketChannel> connectHandler) throws IOException {
+		SocketChannel client = (SocketChannel) key.channel();
+		debug("client={}", client);
+		client.configureBlocking(false);
+		client.register(this.selector, SelectionKey.OP_READ, new AttachedIO());
+		if (client.isConnectionPending()) {
+			client.finishConnect();
+			debug("connected client={}", client);
+		}
+		if (connectHandler != null) {
+			connectHandler.apply(client);
+		}
+	}
+
+	protected void handleAcceptable(SelectionKey key, IOConsumer<SocketChannel> acceptHandler) throws IOException {
+		ServerSocketChannel serverSocket = (ServerSocketChannel) key.channel();
+		SocketChannel client = serverSocket.accept();
+		debug("client={}", client);
+		client.configureBlocking(false);
+		client.register(this.selector, SelectionKey.OP_READ, new AttachedIO());
+		configureAcceptSocketChannel(client);
+		if (client.isConnectionPending()) {
+			client.finishConnect();
+			debug("accepted client={}", client);
+		}
+		if (acceptHandler != null) {
+			acceptHandler.apply(client);
+		}
+	}
+
+	protected void configureAcceptSocketChannel(SocketChannel client) throws IOException {
+		// Subclasses may override
+	}
+
+	protected AttachedIO getAttachedIO(SelectionKey key) throws IOException {
+		AttachedIO io = (AttachedIO) key.attachment();
+		if (io == null) {
+			throw new IOException("No AttachedIO object found on key");
+		}
+		return io;
+	}
+
+	protected void handleReadable(SelectionKey key, IOConsumer<String> readHandler) throws IOException {
+		SocketChannel client = (SocketChannel) key.channel();
+		AttachedIO io = getAttachedIO(key);
+		debug("read client={}", client);
+		// read
+		int r = client.read(this.inBuffer);
+		// Check if we should expect any more reads
+		if (r == -1) {
+			throw new IOException("Channel read reached end of stream");
+		}
+		this.inBuffer.flip();
+		String partial = new String(this.inBuffer.array(), 0, r, StandardCharsets.UTF_8);
+		// If there is previous partial, get the io.reading string Buffer
+		StringBuffer sb = (io.reading != null) ? (StringBuffer) io.reading : new StringBuffer();
+		// append the just read partial to the existing or new string buffer
+		sb.append(partial);
+		if (partial.endsWith(messageDelimiter)) {
+			// Get the entire message from the string buffer
+			String message = sb.toString();
+			// Set the io.reading value to null as we are done with this message
+			io.reading = null;
+			debug("read client={} msg=", client, message);
+			if (readHandler != null) {
+				String[] messages = splitMessage(message);
+				for (int i = 0; i < messages.length; i++) {
+					readHandler.apply(messages[i]);
+				}
+			}
+		} else {
+			io.reading = sb;
+			debug("read partial={}", partial);
+		}
+		// Clear inbuffer for next read
+		this.inBuffer.clear();
+	}
+
+	protected void handleWritable(SelectionKey key) throws IOException {
+		ByteBuffer buf = getAttachedIO(key).writing;
+		SocketChannel client = (SocketChannel) key.channel();
+		if (buf != null) {
+			doWrite(key, client, buf, (o) -> {
+				synchronized (writeLock) {
+					writeLock.notifyAll();
+				}
+			});
+		}
+	}
+
+	protected void doWrite(SocketChannel client, String message, IOConsumer<Object> writeHandler) throws IOException {
+		Objects.requireNonNull(client, "Client must not be null");
+		Objects.requireNonNull(message, "Message must not be null");
+		doWrite(client.keyFor(this.selector), client, ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)),
+				writeHandler);
+	}
+
+	protected void doWrite(SelectionKey key, SocketChannel client, ByteBuffer buf, IOConsumer<Object> writeHandler)
+			throws IOException {
+		AttachedIO io = (AttachedIO) key.attachment();
+		synchronized (writeLock) {
+			int written = client.write(buf);
+			if (buf.hasRemaining()) {
+				debug("doWrite written={}, remaining={}", written, buf.remaining());
+				io.writing = buf.slice();
+				key.interestOpsOr(SelectionKey.OP_WRITE);
+			} else {
+				if (logger.isDebugEnabled()) {
+					logger.debug("doWrite message={}", new String(buf.array(), 0, written));
+				}
+				io.writing = null;
+				key.interestOps(SelectionKey.OP_READ);
+				if (writeHandler != null) {
+					writeHandler.apply(null);
+				}
+			}
+		}
+	}
+
+	protected void executorShutdown() {
+		if (!this.executor.isShutdown()) {
+			debug("shutdown");
+			try {
+				this.executor.awaitTermination(this.terminationTimeout, TimeUnit.MILLISECONDS);
+				this.executor.shutdown();
+			} catch (InterruptedException e) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Exception in executor awaitTermination", e);
+				}
+			}
+		}
+	}
+
+	protected void hardCloseClient(SocketChannel client, IOConsumer<SocketChannel> closeHandler) {
+		if (client != null) {
+			debug("hardClose client={}", client);
+			synchronized (writeLock) {
+				try {
+					if (closeHandler != null) {
+						closeHandler.apply(client);
+					}
+					client.close();
+				} catch (IOException e) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("hardClose client socketchannel.close exception", e);
+					}
+				}
+			}
+			executorShutdown();
+		}
+	}
+
+	protected void writeMessageToChannel(SocketChannel client, String message) throws IOException {
+		Objects.requireNonNull(client, "Client must not be null");
+		Objects.requireNonNull(message, "Message must not be null");
+		// Escape any embedded newlines in the JSON message
+		String outputMessage = message.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+				// add message delimiter
+				.concat(DEFAULT_MESSAGE_DELIMITER);
+		debug("writing msg={}", outputMessage);
+		synchronized (writeLock) {
+			// do the non blocking write in thread while holding lock.
+			doWrite(client, outputMessage, null);
+			ByteBuffer bufRemaining = null;
+			long waitTime = System.currentTimeMillis() + this.writeTimeout;
+			while (waitTime - System.currentTimeMillis() > 0) {
+				// Before releasing lock, check for writing buffer remaining
+				bufRemaining = getAttachedIO(client.keyFor(this.selector)).writing;
+				if (bufRemaining == null || bufRemaining.remaining() == 0) {
+					// It's done
+					break;
+				}
+				// If write is *not* completed, then wait timeout /10
+				try {
+					debug("writeBlocking WAITING(ms)={} msg={}", String.valueOf(waitTime / 10), outputMessage);
+					writeLock.wait(waitTime / 10);
+				} catch (InterruptedException e) {
+					throw new InterruptedIOException("write message wait interrupted");
+				}
+			}
+			if (bufRemaining != null && bufRemaining.remaining() > 0) {
+				throw new IOException("Write not completed.  Non empty buffer remaining after timeout");
+			}
+		}
+		debug("writing done msg={}", outputMessage);
+	}
+
+	protected void configureConnectSocketChannel(SocketChannel client, SocketAddress connectAddress)
+			throws IOException {
+		// Subclasses may override
+	}
+
+	protected String[] splitMessage(String message) {
+		return (message == null) ? new String[0] : message.split(messageDelimiter);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/ClientStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/ClientStringChannel.java
@@ -1,0 +1,111 @@
+/****************************************************************************
+ * Copyright (c) 2004 Composent, Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientStringChannel extends AbstractStringChannel {
+
+	private static final Logger logger = LoggerFactory.getLogger(ClientStringChannel.class);
+
+	protected SocketChannel client;
+
+	protected final Object connectLock = new Object();
+
+	public ClientStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public ClientStringChannel() throws IOException {
+		super();
+	}
+
+	public ClientStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public ClientStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	protected SocketChannel doConnect(SocketChannel client, SocketAddress address,
+			IOConsumer<SocketChannel> connectHandler, IOConsumer<String> readHandler) throws IOException {
+		debug("connect targetAddress={}", address);
+		client.configureBlocking(false);
+		client.register(selector, SelectionKey.OP_CONNECT);
+		configureConnectSocketChannel(client, address);
+		// Start the read thread before connect
+		// No/null accept handler for clients
+		start(null, (c) -> {
+			synchronized (connectLock) {
+				if (connectHandler != null) {
+					connectHandler.apply(c);
+				}
+				connectLock.notifyAll();
+			}
+		}, readHandler);
+
+		client.connect(address);
+		try {
+			debug("connect targetAddress={}", address);
+			synchronized (connectLock) {
+				connectLock.wait(this.connectTimeout);
+			}
+		} catch (InterruptedException e) {
+			throw new IOException(
+					"Connect to address=" + address + " timed out after " + String.valueOf(this.connectTimeout) + "ms");
+		}
+		debug("connected client={}", client);
+		return client;
+	}
+
+	public void connect(StandardProtocolFamily protocol, SocketAddress address,
+			IOConsumer<SocketChannel> connectHandler, IOConsumer<String> readHandler) throws IOException {
+		if (this.client != null) {
+			throw new IOException("Already connected");
+		}
+		this.client = doConnect(SocketChannel.open(protocol), address, connectHandler, readHandler);
+	}
+
+	@Override
+	protected void handleException(SelectionKey key, Throwable e) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("handleException", e);
+		}
+		close();
+	}
+
+	@Override
+	public void close() {
+		hardCloseClient(this.client, (client) -> {
+			this.client = null;
+		});
+	}
+
+	public void writeMessage(String message) throws IOException {
+		if (this.client == null) {
+			throw new IOException("Cannot write until client connected");
+		}
+		writeMessageToChannel(client, message);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet4ClientStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet4ClientStringChannel.java
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class Inet4ClientStringChannel extends ClientStringChannel {
+
+	public Inet4ClientStringChannel() throws IOException {
+		super();
+	}
+
+	public Inet4ClientStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public Inet4ClientStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public Inet4ClientStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void connectBlocking(Inet4Address address, int port, IOConsumer<SocketChannel> connectHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.connect(StandardProtocolFamily.INET, new InetSocketAddress(address, port), connectHandler, readHandler);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet4ServerStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet4ServerStringChannel.java
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class Inet4ServerStringChannel extends ServerStringChannel {
+
+	public Inet4ServerStringChannel() throws IOException {
+		super();
+	}
+
+	public Inet4ServerStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public Inet4ServerStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public Inet4ServerStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void start(Inet4Address address, int port, IOConsumer<SocketChannel> acceptHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.start(StandardProtocolFamily.INET, new InetSocketAddress(address, port), acceptHandler, readHandler);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet6ClientStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet6ClientStringChannel.java
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class Inet6ClientStringChannel extends ClientStringChannel {
+
+	public Inet6ClientStringChannel() throws IOException {
+		super();
+	}
+
+	public Inet6ClientStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public Inet6ClientStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public Inet6ClientStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void connect(Inet6Address address, int port, IOConsumer<SocketChannel> connectHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.connect(StandardProtocolFamily.INET6, new InetSocketAddress(address, port), connectHandler, readHandler);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet6ServerStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/Inet6ServerStringChannel.java
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class Inet6ServerStringChannel extends ServerStringChannel {
+
+	public Inet6ServerStringChannel() throws IOException {
+		super();
+	}
+
+	public Inet6ServerStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public Inet6ServerStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public Inet6ServerStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void start(Inet6Address address, int port, IOConsumer<SocketChannel> acceptHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.start(StandardProtocolFamily.INET6, new InetSocketAddress(address, port), acceptHandler, readHandler);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/ServerStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/ServerStringChannel.java
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServerStringChannel extends AbstractStringChannel {
+
+	private static final Logger logger = LoggerFactory.getLogger(ServerStringChannel.class);
+
+	protected SocketChannel acceptedClient;
+
+	public ServerStringChannel() throws IOException {
+		super();
+	}
+
+	public ServerStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public ServerStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public ServerStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	protected void configureServerSocketChannel(java.nio.channels.ServerSocketChannel serverSocketChannel,
+			SocketAddress acceptAddress) {
+		// Subclasses may override
+	}
+
+	public void start(StandardProtocolFamily protocol, SocketAddress address, IOConsumer<SocketChannel> acceptHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		java.nio.channels.ServerSocketChannel serverChannel = java.nio.channels.ServerSocketChannel.open(protocol);
+		serverChannel.configureBlocking(false);
+		serverChannel.register(this.selector, SelectionKey.OP_ACCEPT);
+		configureServerSocketChannel(serverChannel, address);
+		serverChannel.bind(address);
+		// Start thread/processing of incoming accept, read
+		super.start((client) -> {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Setting client=" + client);
+			}
+			this.acceptedClient = client;
+			if (acceptHandler != null) {
+				acceptHandler.apply(this.acceptedClient);
+			}
+			// No/null connect handler for Acceptors...only accepthandler
+		}, null, readHandler);
+	}
+
+	@Override
+	protected void handleException(SelectionKey key, Throwable e) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("handleException", e);
+		}
+		close();
+	}
+
+	public void writeMessage(String message) throws IOException {
+		SocketChannel c = this.acceptedClient;
+		if (c != null) {
+			writeMessageToChannel(c, message);
+		} else {
+			throw new IOException("not connected");
+		}
+	}
+
+	@Override
+	public void close() {
+		SocketChannel client = this.acceptedClient;
+		if (client != null) {
+			hardCloseClient(client, (c) -> {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Unsetting client=" + c);
+				}
+				this.acceptedClient = null;
+			});
+		}
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/UDSClientStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/UDSClientStringChannel.java
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class UDSClientStringChannel extends ClientStringChannel {
+
+	public UDSClientStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public UDSClientStringChannel() throws IOException {
+		super();
+	}
+
+	public UDSClientStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public UDSClientStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void connect(UnixDomainSocketAddress address, IOConsumer<SocketChannel> connectHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.connect(StandardProtocolFamily.UNIX, address, connectHandler, readHandler);
+	}
+
+}

--- a/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/UDSServerStringChannel.java
+++ b/framework/bundles/org.eclipse.ecf.ai.mcp.transports/src/org/eclipse/ecf/ai/mcp/transports/UDSServerStringChannel.java
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * Copyright (c) 2025 Composent, Inc. 
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *    Composent, Inc. - initial API and implementation
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.ecf.ai.mcp.transports;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.ExecutorService;
+
+public class UDSServerStringChannel extends ServerStringChannel {
+
+	public UDSServerStringChannel() throws IOException {
+		super();
+	}
+
+	public UDSServerStringChannel(Selector selector, int incomingBufferSize, ExecutorService executor) {
+		super(selector, incomingBufferSize, executor);
+	}
+
+	public UDSServerStringChannel(Selector selector, int incomingBufferSize) {
+		super(selector, incomingBufferSize);
+	}
+
+	public UDSServerStringChannel(Selector selector) {
+		super(selector);
+	}
+
+	public void start(UnixDomainSocketAddress address, IOConsumer<SocketChannel> acceptHandler,
+			IOConsumer<String> readHandler) throws IOException {
+		super.start(StandardProtocolFamily.UNIX, address, acceptHandler, readHandler);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,8 @@
     <url>https://github.com/eclipse/ecf/issues</url>
     <system>GitHub</system>
   </issueManagement>
-
+<!-- 
   <distributionManagement>
-    <repository>
-      <id>repo.eclipse.org</id>
-      <name>ECF Maven Repository - Releases</name>
-      <url>https://repo.eclipse.org/content/repositories/ecf-releases/</url>
-    </repository>
     <snapshotRepository>
       <id>repo.eclipse.org</id>
       <name>ECF Maven Repository - Snapshots</name>
@@ -70,7 +65,7 @@
       <uniqueVersion>true</uniqueVersion>
     </snapshotRepository>
   </distributionManagement>
-
+-->
   <properties>
     <tycho-version>4.0.10</tycho-version>
     <cbi-version>1.5.2</cbi-version>
@@ -384,7 +379,7 @@
           <extensions>true</extensions>
           <configuration>
              <publishingServerId>central</publishingServerId>
-             <autoPublish>true</autoPublish>
+             <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
              <ignorePublishedComponents>true</ignorePublishedComponents>
              <deploymentName>ECF Release</deploymentName>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,9 @@
 	<!-- Model Context Protocol Tooling Support Bundle -->
     <module>framework/bundles/org.eclipse.ecf.ai.mcp.tools</module>
 
+	<!-- Model Context Protocol Transport Support Bundle -->
+    <module>framework/bundles/org.eclipse.ecf.ai.mcp.transports</module>
+
 	<!-- A2A Tooling Support Bundle -->
     <module>framework/bundles/org.eclipse.ecf.ai.a2a</module>
 

--- a/releng/features/org.eclipse.ecf.ai.mcp.tools.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.ai.mcp.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.ai.mcp.tools.feature"
       label="ECF AI Model Context Protocol Tool Support Feature"
-      version="2.1.1.qualifier"
+      version="2.2.0.qualifier"
       provider-name="Eclipse.org - ECF"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -21,6 +21,10 @@
 
    <plugin
          id="org.eclipse.ecf.ai.mcp.tools"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.ecf.ai.mcp.transports"
          version="0.0.0"/>
 
 </feature>

--- a/releng/features/org.eclipse.ecf.ai.mcp.tools.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.ai.mcp.tools.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.ai.mcp.tools.feature</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
+++ b/releng/org.eclipse.ecf.releng.target/ecf-2024-06.target
@@ -63,6 +63,10 @@
       <unit id="org.sat4j.pb" version="0.0.0"/>
       <unit id="org.tukaani.xz" version="0.0.0"/>
       <unit id="org.xbill.dns" version="0.0.0"/>
+      <unit id="slf4j.api" version="0.0.0"/>
+      <unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
+      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
+      <unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Initial checkin of org.eclipse.ecf.ai.mcp.transports bundle.  Added Unix Domain Socket, Inet4 and Inet6 MCP client/server transports.