### PR TITLE
Fix for issue #246

### DIFF
--- a/doc/bundles/org.eclipse.ecf.doc/pom.xml
+++ b/doc/bundles/org.eclipse.ecf.doc/pom.xml
@@ -30,8 +30,8 @@
                   <additionalArgument>-Xdoclint:none</additionalArgument>
                   <additionalArgument>-splitindex</additionalArgument>
                   <additionalArgument>-use</additionalArgument>
-                  <additionalArgument>-doctitle "Eclipse Communication Framework (ECF) 3.16.7 API"</additionalArgument>
-                  <additionalArgument>-windowtitle "Eclipse Communication Framework (ECF) 3.16.7 API"</additionalArgument>
+                  <additionalArgument>-doctitle "Eclipse Communication Framework (ECF) 3.16.8 API"</additionalArgument>
+                  <additionalArgument>-windowtitle "Eclipse Communication Framework (ECF) 3.16.8 API"</additionalArgument>
                   <additionalArgument>-link https://docs.oracle.com/en/java/javase/11/docs/api/</additionalArgument>
                   <additionalArgument>-link https://docs.osgi.org/javadoc/osgi.core/7.0.0/</additionalArgument>
                   <additionalArgument>-tag 'noimplement:a:Restriction:'</additionalArgument>

--- a/framework/bundles/org.eclipse.ecf.identity/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf.identity/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf.identity;singleton:=true
 Automatic-Module-Name: org.eclipse.ecf.identity
-Bundle-Version: 3.10.1.qualifier
+Bundle-Version: 3.10.200.qualifier
 Bundle-Activator: org.eclipse.ecf.internal.core.identity.Activator
 Bundle-Localization: plugin
 Bundle-Vendor: %plugin.provider

--- a/framework/bundles/org.eclipse.ecf.identity/pom.xml
+++ b/framework/bundles/org.eclipse.ecf.identity/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.ecf</groupId>
   <artifactId>org.eclipse.ecf.identity</artifactId>
-  <version>3.10.1-SNAPSHOT</version>
+  <version>3.10.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.eclipse.ecf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.ecf;singleton:=true
 Automatic-Module-Name: org.eclipse.ecf
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Activator: org.eclipse.ecf.internal.core.ECFPlugin
 Bundle-Vendor: %plugin.provider
 Bundle-Localization: plugin

--- a/framework/bundles/org.eclipse.ecf/pom.xml
+++ b/framework/bundles/org.eclipse.ecf/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf</artifactId>
-  <version>3.13.0-SNAPSHOT</version>
+  <version>3.13.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.base.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.base.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.base.feature"
       label="ECF Base Feature"
-      version="3.0.0.qualifier"
+      version="3.0.100.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.console.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.console.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.console.feature"
       label="ECF Console Feature"
-      version="1.4.0.qualifier"
+      version="1.4.100.qualifier"
       provider-name="Eclipse.org - ECF"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -21,7 +21,7 @@
    </license>
 
    <requires>
-      <import plugin="org.eclipse.ecf" version="3.10.0" match="compatible"/>
+      <import plugin="org.eclipse.ecf" version="3.10.100" match="compatible"/>
       <import plugin="org.eclipse.ecf.identity"/>
    </requires>
 

--- a/releng/features/org.eclipse.ecf.console.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.console.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.console.feature</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.core.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.core.feature"
       label="ECF Core Feature"
-      version="1.7.0.qualifier"
+      version="1.7.100.qualifier"
       provider-name="Eclipse.org - ECF"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.core.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.core.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.core.feature</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.7.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.core/feature.xml
+++ b/releng/features/org.eclipse.ecf.core/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.core"
       label="ECF SDK for Eclipse"
-      version="3.16.7.qualifier"
+      version="3.16.8.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.ecf"
       license-feature="org.eclipse.license"

--- a/releng/features/org.eclipse.ecf.core/pom.xml
+++ b/releng/features/org.eclipse.ecf.core/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.ecf</groupId>
   <artifactId>org.eclipse.ecf.core</artifactId>
-  <version>3.16.7-SNAPSHOT</version>
+  <version>3.16.8-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.datashare.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.datashare.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.datashare.feature"
       label="ECF Datashare"
-      version="1.1.0.qualifier"
+      version="1.1.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.datashare.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.datashare.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.datashare.feature</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.discovery.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.discovery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.discovery.feature"
       label="ECF Discovery"
-      version="1.1.0.qualifier"
+      version="1.1.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.discovery.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.discovery.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.discovery.feature</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.filetransfer.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.filetransfer.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.filetransfer.feature"
       label="%featureName"
-      version="3.15.0.qualifier"
+      version="3.15.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.filetransfer.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.filetransfer.feature/pom.xml
@@ -9,6 +9,6 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.filetransfer.feature</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.presence.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.presence.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.presence.feature"
       label="ECF Presence API Feature"
-      version="1.1.0.qualifier"
+      version="1.1.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.presence.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.presence.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.presence.feature</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.remoteservice.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.remoteservice.feature"
       label="ECF Remote Services"
-      version="2.7.0.qualifier"
+      version="2.7.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.remoteservice.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.remoteservice.feature</artifactId>
-  <version>2.7.0-SNAPSHOT</version>
+  <version>2.7.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.bndtools.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.bndtools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.remoteservice.sdk.bndtools.feature"
       label="ECF Remote Services SDK for Bndtools"
-      version="3.16.7.qualifier"
+      version="3.16.8.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.bndtools.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.bndtools.feature/pom.xml
@@ -9,6 +9,6 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.remoteservice.sdk.bndtools.feature</artifactId>
-  <version>3.16.7-SNAPSHOT</version>
+  <version>3.16.8-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.eclipse.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.remoteservice.sdk.eclipse.feature"
       label="ECF Remote Services SDK for Eclipse"
-      version="3.16.7.qualifier"
+      version="3.16.8.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.eclipse.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.eclipse.feature/pom.xml
@@ -9,6 +9,6 @@
     <relativePath>../../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.remoteservice.sdk.eclipse.feature</artifactId>
-  <version>3.16.7-SNAPSHOT</version>
+  <version>3.16.8-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.remoteservice.sdk.feature"
       label="ECF Remote Services SDK for OSGi clients and servers"
-      version="3.16.7.qualifier"
+      version="3.16.8.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.remoteservice.sdk.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.remoteservice.sdk.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.ecf</groupId>
   <artifactId>org.eclipse.ecf.remoteservice.sdk.feature</artifactId>
-  <version>3.16.7-SNAPSHOT</version>
+  <version>3.16.8-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/features/org.eclipse.ecf.sdk/feature.xml
+++ b/releng/features/org.eclipse.ecf.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.sdk"
       label="%featureName"
-      version="3.16.7.qualifier"
+      version="3.16.8.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.sharedobject.feature/feature.xml
+++ b/releng/features/org.eclipse.ecf.sharedobject.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.ecf.sharedobject.feature"
       label="ECF SharedObject Feature"
-      version="1.2.0.qualifier"
+      version="1.2.100.qualifier"
       provider-name="Eclipse.org - ECF"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/features/org.eclipse.ecf.sharedobject.feature/pom.xml
+++ b/releng/features/org.eclipse.ecf.sharedobject.feature/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   
   <artifactId>org.eclipse.ecf.sharedobject.feature</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/releng/org.eclipse.ecf.releng.bm/karaf/features/karaf-features.xml
+++ b/releng/org.eclipse.ecf.releng.bm/karaf/features/karaf-features.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
-	name="ecf-remoteservices-sdk-3.16.7">
-	<feature name="ecf-rs-dependencies-supplement" version="3.16.7" description="ECF 3.16.7 RemoteServices External Dependencies Supplemental. https://wiki.eclipse.org/ECF#OSGi_Remote_Services">
+	name="ecf-remoteservices-sdk-3.16.8">
+	<feature name="ecf-rs-dependencies-supplement" version="3.16.8" description="ECF 3.16.8 RemoteServices External Dependencies Supplemental. https://wiki.eclipse.org/ECF#OSGi_Remote_Services">
 		<bundle>mvn:org.eclipse.platform/org.eclipse.equinox.supplement/1.7.0</bundle>
 	</feature>		
 
-	<feature name="ecf-rs-dependencies" version="3.16.7"
-		description="ECF 3.16.7 RemoteServices External Dependencies. https://wiki.eclipse.org/ECF#OSGi_Remote_Services">
-		<feature version="3.16.7">ecf-rs-dependencies-supplement</feature>
+	<feature name="ecf-rs-dependencies" version="3.16.8"
+		description="ECF 3.16.8 RemoteServices External Dependencies. https://wiki.eclipse.org/ECF#OSGi_Remote_Services">
+		<feature version="3.16.8">ecf-rs-dependencies-supplement</feature>
 		<bundle>
 			mvn:org.eclipse.platform/org.eclipse.equinox.common/3.9.0
 		</bundle>
@@ -21,9 +21,9 @@
 		<feature>eventadmin</feature>
 	</feature>
 	
-	<feature name="ecf-rs-core" version="3.16.7"
+	<feature name="ecf-rs-core" version="3.16.8"
 		description="ECF Core">
-		<feature version="3.16.7">ecf-rs-dependencies</feature>
+		<feature version="3.16.8">ecf-rs-dependencies</feature>
 		<bundle> mvn:org.eclipse.ecf/org.eclipse.ecf.identity</bundle>
 		<bundle> mvn:org.eclipse.ecf/org.eclipse.ecf</bundle>
 		<bundle>
@@ -39,16 +39,16 @@
 			mvn:org.eclipse.ecf/org.eclipse.ecf.remoteservice
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-console" version="3.16.7"
+	<feature name="ecf-rs-console" version="3.16.8"
 		description="ECF Console">
 		<bundle> mvn:org.eclipse.ecf/org.eclipse.ecf.console</bundle>
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.osgi.services.remoteserviceadmin.console
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-rsa-impl" version="3.16.7"
+	<feature name="ecf-rs-rsa-impl" version="3.16.8"
 		description="ECF RemoteServices OSGi R7 Remote Service Admin (RSA) Impl. See https://wiki.eclipse.org/Remote_Services_Admin">
-		<feature version="3.16.7">ecf-rs-core</feature>
+		<feature version="3.16.8">ecf-rs-core</feature>
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.osgi.services.remoteserviceadmin
 		</bundle>
@@ -59,28 +59,28 @@
 			mvn:org.eclipse.ecf/org.eclipse.ecf.osgi.services.remoteserviceadmin
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-rsa-topology-manager" version="3.16.7"
+	<feature name="ecf-rs-rsa-topology-manager" version="3.16.8"
 		description="ECF RemoteServices OSGi R7 Default Topology Manager (promiscuous). See https://wiki.eclipse.org/Remote_Services_Admin">
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.osgi.services.distribution
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-rsa" version="3.16.7"
-		description="ECF 3.16.7 Remote Service Admin">
-		<feature version="3.16.7">ecf-rs-rsa-impl</feature>
-		<feature version="3.16.7">ecf-rs-rsa-topology-manager</feature>
+	<feature name="ecf-rs-rsa" version="3.16.8"
+		description="ECF 3.16.8 Remote Service Admin">
+		<feature version="3.16.8">ecf-rs-rsa-impl</feature>
+		<feature version="3.16.8">ecf-rs-rsa-topology-manager</feature>
 	</feature>
-	<feature name="ecf-rs-distribution-generic" version="3.16.7"
+	<feature name="ecf-rs-distribution-generic" version="3.16.8"
 		description="ECF RemoteServices Generic Distribution Provider. https://wiki.eclipse.org/EIG:Configuration_Properties">
-		<feature version="3.16.7">ecf-rs-rsa</feature>
+		<feature version="3.16.8">ecf-rs-rsa</feature>
 		<bundle> mvn:org.eclipse.ecf/org.eclipse.ecf.provider</bundle>
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.provider.remoteservice
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-distribution-rosgi" version="3.16.7"
+	<feature name="ecf-rs-distribution-rosgi" version="3.16.8"
 		description="ECF RemoteService ROSGi Distribution Provider. https://wiki.eclipse.org/EIG:Configuration_Properties">
-		<feature version="3.16.7">ecf-rs-rsa</feature>
+		<feature version="3.16.8">ecf-rs-rsa</feature>
 		<bundle>mvn:org.eclipse.ecf/org.objectweb.asm</bundle>
 		<bundle>
 			mvn:org.eclipse.ecf/ch.ethz.iks.r_osgi.remote
@@ -90,62 +90,62 @@
 			mvn:org.eclipse.ecf/org.eclipse.ecf.provider.r_osgi
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-discovery-jmdns" version="3.16.7"
+	<feature name="ecf-rs-discovery-jmdns" version="3.16.8"
 		description="ECF RemoteServices JMDNS Discovery Provider">
-		<feature version="3.16.7">ecf-rs-rsa</feature>
+		<feature version="3.16.8">ecf-rs-rsa</feature>
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.provider.jmdns
 		</bundle>
 	</feature>
-	<feature name="ecf-ai-mcp" version="3.16.7"
-		description="ECF 3.16.7 AI Model Context Protocol Remote Tool Support">
+	<feature name="ecf-ai-mcp" version="3.16.8"
+		description="ECF 3.16.8 AI Model Context Protocol Remote Tool Support">
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.ai.mcp.tools
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-eventadmin" version="3.16.7"
-		description="ECF 3.16.7 RemoteServices SDK Distributed EventAdmin">
-		<feature version="3.16.7">ecf-rs-rsa</feature>
+	<feature name="ecf-rs-eventadmin" version="3.16.8"
+		description="ECF 3.16.8 RemoteServices SDK Distributed EventAdmin">
+		<feature version="3.16.8">ecf-rs-rsa</feature>
 		<bundle>
 			mvn:org.eclipse.ecf/org.eclipse.ecf.remoteservice.eventadmin
 		</bundle>
 	</feature>
 	<feature name="ecf-rs-examples-timeservice-api"
-		version="3.16.7"
+		version="3.16.8"
 		description="ECF RemoteService TimeService Example API. See https://wiki.eclipse.org/Tutorial:_Building_your_first_OSGi_Remote_Service">
 		<bundle>
 			https://download.eclipse.org/rt/ecf/3.14.19/site.p2/3.14.19.v20210101-2239/plugins/com.mycorp.examples.timeservice.async_2.1.100.v20200611-1508.jar
 		</bundle>
 	</feature>
 	<feature name="ecf-rs-examples-timeservice-host"
-		version="3.16.7"
+		version="3.16.8"
 		description="ECF RemoteService TimeService Example Host. See https://wiki.eclipse.org/Tutorial:_Building_your_first_OSGi_Remote_Service">
-		<feature version="3.16.7">ecf-rs-examples-timeservice-api</feature>
+		<feature version="3.16.8">ecf-rs-examples-timeservice-api</feature>
 		<bundle>
 			https://download.eclipse.org/rt/ecf/3.14.19/site.p2/3.14.19.v20210101-2239/plugins/com.mycorp.examples.timeservice.host_1.1.300.v20200611-1508.jar
 		</bundle>
 	</feature>
 	<feature name="ecf-rs-examples-timeservice-consumer-async"
-		version="3.16.7"
+		version="3.16.8"
 		description="ECF RemoteService TimeService Async Example Consumer.  See https://wiki.eclipse.org/Tutorial:_Building_your_first_OSGi_Remote_Service">
-		<feature version="3.16.7">ecf-rs-examples-timeservice-api</feature>
+		<feature version="3.16.8">ecf-rs-examples-timeservice-api</feature>
 		<bundle>
 			https://download.eclipse.org/rt/ecf/3.14.19/site.p2/3.14.19.v20210101-2239/plugins/com.mycorp.examples.timeservice.consumer.ds.async_1.0.200.v20200611-1508.jar
 		</bundle>
 	</feature>
-	<feature name="ecf-rs-sdk" version="3.16.7"
-		description="ECF 3.16.7 RemoteServices SDK with Generic Distribution Provider and Zeroconf Multicast LAN Discovery Provider">
-		<feature version="3.16.7">ecf-rs-distribution-generic</feature>
-		<feature version="3.16.7">ecf-rs-discovery-jmdns</feature>
-		<feature version="3.16.7">ecf-rs-console</feature>
+	<feature name="ecf-rs-sdk" version="3.16.8"
+		description="ECF 3.16.8 RemoteServices SDK with Generic Distribution Provider and Zeroconf Multicast LAN Discovery Provider">
+		<feature version="3.16.8">ecf-rs-distribution-generic</feature>
+		<feature version="3.16.8">ecf-rs-discovery-jmdns</feature>
+		<feature version="3.16.8">ecf-rs-console</feature>
 	</feature>
 	<feature name="ecf-rs-sdk-examples-timeservicehost"
-		version="3.16.7"
-		description="ECF 3.16.7 RemoteServices SDK with Generic Distribution Provider and Zeroconf Multicast LAN Discovery Provider">
-		<feature version="3.16.7">ecf-rs-distribution-generic</feature>
-		<feature version="3.16.7">ecf-rs-discovery-jmdns</feature>
-		<feature version="3.16.7">ecf-rs-console</feature>
-		<feature version="3.16.7">ecf-rs-examples-timeservice-host</feature>
+		version="3.16.8"
+		description="ECF 3.16.8 RemoteServices SDK with Generic Distribution Provider and Zeroconf Multicast LAN Discovery Provider">
+		<feature version="3.16.8">ecf-rs-distribution-generic</feature>
+		<feature version="3.16.8">ecf-rs-discovery-jmdns</feature>
+		<feature version="3.16.8">ecf-rs-console</feature>
+		<feature version="3.16.8">ecf-rs-examples-timeservice-host</feature>
 	</feature>
 	<repository>https://raw.githubusercontent.com/ECF/XmlRpcProvider/master/build/karaf-features.xml</repository>
 	<!-- Include Py4j RemoteServicesProvider -->

--- a/releng/org.eclipse.ecf.releng.repository/pom.xml
+++ b/releng/org.eclipse.ecf.releng.repository/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>org.eclipse.ecf.releng.repository</artifactId>
-  <version>3.16.7-SNAPSHOT</version>
+  <version>3.16.8-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 
   <name>ECF p2 Repository</name>


### PR DESCRIPTION

Increment of bundle versions for org.eclipse.ecf and org.eclipse.ecf.identity for split package signing issue:   https://github.com/eclipse-ecf/ecf/issues/246

Also updated features and top-level features to 3.16.8 for subsequent release